### PR TITLE
Added a cache of jar/classes relationship

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,3 +29,5 @@ publishing {
     }
   }
 }
+
+tasks.withType(PublishToMavenRepository) {it.dependsOn check}


### PR DESCRIPTION
Multiproject builds often have many projects depending on the same artifact, in those cases, the plugin would inspect such jars many times, this change caches the results for the duration of a build